### PR TITLE
完成用户创建passport 和 robot,以及领取每日token的流程及测试

### DIFF
--- a/contract/sources/calculate.move
+++ b/contract/sources/calculate.move
@@ -54,8 +54,9 @@ module robobo::calculate {
             ((bytes[3] + bytes[11] + bytes[19] + bytes[27]) * speed_range) / 255;
 
         // Personality uses same pattern but with 0-100 range
+        // Ensure we don't overflow u8 by scaling down the sum first
         let personality = zero_point + 
-            ((bytes[4] + bytes[12] + bytes[20] + bytes[28]) * 100) / 255;
+            ((bytes[4] + bytes[12] + bytes[20] + bytes[28]) / 4 * 100) / 255;
 
         // Convert final u64 values to u8 (safe as all results are within 0-255 range)
         (attack as u8, defense as u8, speed as u8, energy as u8, personality as u8)

--- a/contract/sources/game.move
+++ b/contract/sources/game.move
@@ -2,18 +2,26 @@ module robobo::game {
     use sui::object::{Self, UID, ID};
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
-    use sui::clock::Clock;
+    use sui::clock::{Self, Clock};
     use sui::table::{Self, Table};
     use std::string::String;
     use robobo::user::{Self, Passport};
-    use robobo::trash::{Self, TrashTokenCap};
+    use robobo::trash::{Self, TrashTokenCap, TRASH};
     use robobo::robot::{Self, Robot, Robot_Pool};
+    use sui::token::{Self, Token, TokenPolicy};
 
     // Error codes
     const E_ALREADY_INITIALIZED: u64 = 0;
     const E_NOT_INITIALIZED: u64 = 1;
     const E_ALREADY_HAS_PASSPORT: u64 = 2;
     const E_NO_PASSPORT: u64 = 3;
+    const E_ALREADY_CLAIMED_TODAY: u64 = 4;
+
+    /// 定义游戏中的 TRASH token 数值
+    const TRASH_AMOUNT_MINT_ROBOT: u64 = 10;
+    const TRASH_AMOUNT_DAILY_CLAIM: u64 = 100;
+    // 可以添加更多的数值...
+    // const TRASH_AMOUNT_UPGRADE_ROBOT: u64 = 200;
 
     /// GameState stores the global state of the game
     public struct GameState has key,store {
@@ -50,9 +58,9 @@ module robobo::game {
 
     /// 创建新用户的 Passport
     public entry fun create_passport(
-        game_state: &mut GameState,
         name: String,
-        clock: &Clock,
+        game_state: &mut GameState,
+        token_cap: &mut TrashTokenCap,
         ctx: &mut TxContext
     ) {
         let sender = tx_context::sender(ctx);
@@ -60,27 +68,42 @@ module robobo::game {
         assert!(!table::contains(&game_state.passports, sender), E_ALREADY_HAS_PASSPORT);
         
         // 创建新的 passport 并获取其 ID
-        let passport = user::mint(name, clock, ctx);
+        let passport = user::mint(name, ctx);
         let passport_id = user::get_passport_id(&passport);
         
         // 记录用户的 passport
         table::add(&mut game_state.passports, sender, passport_id);
         
+        // 铸造 TRASH token 给用户
+        trash::mint(token_cap, TRASH_AMOUNT_DAILY_CLAIM, ctx);
+
         // 转移 passport 给用户
         user::transfer_passport(passport, sender);
     }
 
-    /// 为新用户创建初始机器人,第一次是免费的
-    public entry fun create_initial_robot(
+    /// 用户创建初始机器人,需要收取TRASH
+    public entry fun mint_robot(
         game_state: &GameState,
         robot_pool: &mut Robot_Pool,
         passport: &mut Passport,
         robot_name: String,
+        mut payment: Token<TRASH>,
+        token_policy: &mut TokenPolicy<TRASH>,
         ctx: &mut TxContext
     ) {
         let sender = tx_context::sender(ctx);
         // 验证 passport 确实属于该用户
         assert!(table::contains(&game_state.passports, sender), E_NO_PASSPORT);
+        
+        // 分割出正确数量的token作为支付，剩余的返还给用户
+        let payment_value = token::value(&payment);
+        if (payment_value > TRASH_AMOUNT_MINT_ROBOT) {
+            let remaining = token::split(&mut payment, payment_value - TRASH_AMOUNT_MINT_ROBOT, ctx);
+            token::keep(remaining, ctx);
+        };
+        
+        // 支付 TRASH token
+        trash::spend(payment, token_policy, TRASH_AMOUNT_MINT_ROBOT, ctx);
         
         // 创建初始机器人并获取其 ID
         let robot = robot::create_robot(robot_name, robot_pool, ctx);
@@ -90,6 +113,23 @@ module robobo::game {
         
         // 转移机器人给用户
         transfer::public_transfer(robot, sender);
+    }
+
+    /// 每日领取 TRASH token
+    public entry fun claim_daily_token(
+        game_state: &GameState,
+        passport: &mut Passport,
+        token_cap: &mut TrashTokenCap,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        // 验证 passport 确实属于该用户
+        assert!(table::contains(&game_state.passports, sender), E_NO_PASSPORT);
+        assert!(user::can_claim_daily_token(passport,ctx), E_ALREADY_CLAIMED_TODAY);
+        // 更新最后领取时间
+        user::update_last_mint_token_time(passport, ctx);
+        // 铸造 TRASH token 给用户
+        trash::mint(token_cap, TRASH_AMOUNT_DAILY_CLAIM, ctx);
     }
 
     // ======== 视图函数 ========

--- a/contract/sources/game.move
+++ b/contract/sources/game.move
@@ -1,0 +1,106 @@
+module robobo::game {
+    use sui::object::{Self, UID, ID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+    use sui::clock::Clock;
+    use sui::table::{Self, Table};
+    use std::string::String;
+    use robobo::user::{Self, Passport};
+    use robobo::trash::{Self, TrashTokenCap};
+    use robobo::robot::{Self, Robot, Robot_Pool};
+
+    // Error codes
+    const E_ALREADY_INITIALIZED: u64 = 0;
+    const E_NOT_INITIALIZED: u64 = 1;
+    const E_ALREADY_HAS_PASSPORT: u64 = 2;
+    const E_NO_PASSPORT: u64 = 3;
+
+    /// GameState stores the global state of the game
+    public struct GameState has key,store {
+        id: UID,
+        // 记录所有用户的 passport
+        passports: Table<address, ID>,
+        // 其他全局状态...
+    }
+
+    /// One-Time-Witness for the module
+    public struct GAME has drop {}
+
+    // ======== 初始化函数 ========
+
+    fun init(otw: GAME, ctx: &mut TxContext) {
+        let game_state = GameState {
+            id: object::new(ctx),
+            passports: table::new(ctx),
+        };
+        let robot_pool = robot::create_robot_pool(ctx);
+        // Share the GameState object
+        transfer::public_share_object(game_state);
+        transfer::public_share_object(robot_pool);
+    }
+
+    // ======== 测试函数 ========
+    #[test_only]
+    public fun init_for_testing(ctx: &mut TxContext) {
+        init(GAME {}, ctx)
+    }
+
+
+    // ======== 入口函数 ========
+
+    /// 创建新用户的 Passport
+    public entry fun create_passport(
+        game_state: &mut GameState,
+        name: String,
+        clock: &Clock,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        // 确保用户还没有 passport
+        assert!(!table::contains(&game_state.passports, sender), E_ALREADY_HAS_PASSPORT);
+        
+        // 创建新的 passport 并获取其 ID
+        let passport = user::mint(name, clock, ctx);
+        let passport_id = user::get_passport_id(&passport);
+        
+        // 记录用户的 passport
+        table::add(&mut game_state.passports, sender, passport_id);
+        
+        // 转移 passport 给用户
+        user::transfer_passport(passport, sender);
+    }
+
+    /// 为新用户创建初始机器人,第一次是免费的
+    public entry fun create_initial_robot(
+        game_state: &GameState,
+        robot_pool: &mut Robot_Pool,
+        passport: &mut Passport,
+        robot_name: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        // 验证 passport 确实属于该用户
+        assert!(table::contains(&game_state.passports, sender), E_NO_PASSPORT);
+        
+        // 创建初始机器人并获取其 ID
+        let robot = robot::create_robot(robot_name, robot_pool, ctx);
+        let robot_id = robot::get_robot_id(&robot);        
+        // 添加机器人到 passport
+        user::add_robot(passport, robot_id);
+        
+        // 转移机器人给用户
+        transfer::public_transfer(robot, sender);
+    }
+
+    // ======== 视图函数 ========
+
+    /// 检查用户是否已经有 passport
+    public fun has_passport(game_state: &GameState, user: address): bool {
+        table::contains(&game_state.passports, user)
+    }
+
+    /// 获取用户的 passport ID
+    public fun get_passport_id(game_state: &GameState, user: address): ID {
+        *table::borrow(&game_state.passports, user)
+    }
+}

--- a/contract/sources/robot.move
+++ b/contract/sources/robot.move
@@ -35,6 +35,13 @@ module robobo::robot {
         personality: u8,
     }
 
+    public(package) fun create_robot_pool(ctx: &mut TxContext): Robot_Pool {
+        Robot_Pool {
+            id: object::new(ctx),
+            mirrors_pool: table::new(ctx),
+        }
+    }
+
     public(package) fun create_robot(name: String, pool: &mut Robot_Pool, ctx: &mut TxContext): Robot {
         let name_hash = hash::keccak256(name.as_bytes());
         let (attack, defense, speed, energy, personality) = calculate_robot_stats_from_hash(name_hash);
@@ -95,5 +102,9 @@ module robobo::robot {
         assert!(table::contains(&pool.mirrors_pool, robot_mirror_id), E_ROBOT_NOT_EXISTS);
         let robot_mirror = table::borrow(&pool.mirrors_pool, robot_mirror_id);
         robot_mirror.personality.to_string()
+    }
+
+    public(package) fun get_robot_id(robot: &Robot): ID {
+        robot.id.to_inner()
     }
 }

--- a/contract/sources/trash.move
+++ b/contract/sources/trash.move
@@ -58,6 +58,11 @@ module robobo::trash {
         transfer::public_freeze_object(metadata);
     }
 
+    #[test_only]
+    public fun init_for_testing(ctx: &mut TxContext) {
+        init(TRASH {}, ctx)
+    }
+    
     public(package) fun mint(token_cap: &mut TrashTokenCap, amount: u64, ctx: &mut TxContext) {
         let t_token = token::mint(&mut token_cap.cap, amount, ctx);
         let req = token::transfer<TRASH>(t_token, ctx.sender(), ctx);

--- a/contract/sources/user.move
+++ b/contract/sources/user.move
@@ -27,34 +27,80 @@ module robobo::user {
         };
         passport
     }
+    public fun get_passport_id(passport: &Passport): ID {
+        passport.id.to_inner()
+    }
 
-    public fun edit_name(passport: &mut Passport, name: String) {
+    public fun edit_name(passport: &mut Passport, name:String){
         passport.name = name;
     }
 
-    public(package) fun update_last_mint_token_time(passport: &mut Passport, clock: &Clock) {
+    public(package) fun update_last_mint_token_time(passport: &mut Passport, clock: &Clock){
         passport.last_mint_token_time = clock::timestamp_ms(clock);
     }
 
-    public(package) fun add_robot(passport: &mut Passport, robot: ID) {
+    public(package) fun add_robot(passport: &mut Passport, robot:ID){
         assert!(!vector::contains(&passport.robots, &robot), E_ROBOT_EXISTS);
         vector::push_back(&mut passport.robots, robot);
     }
 
-    public(package) fun add_element(passport: &mut Passport, element: ID) {
+    public(package) fun add_element(passport: &mut Passport, element:ID){
         assert!(!vector::contains(&passport.elements, &element), E_ELEMENT_EXISTS);
         vector::push_back(&mut passport.elements, element);
     }
 
-    public(package) fun remove_robot(passport: &mut Passport, robot: ID) {
+    public(package) fun remove_robot(passport: &mut Passport, robot:ID){
         let (contains, index) = vector::index_of(&passport.robots, &robot);
         assert!(contains, E_ROBOT_NOT_EXISTS);
         vector::remove(&mut passport.robots, index);
     }
 
-    public(package) fun remove_element(passport: &mut Passport, element: ID) {
+    public(package) fun remove_element(passport: &mut Passport, element:ID){
         let (contains, index) = vector::index_of(&passport.elements, &element);
         assert!(contains, E_ELEMENT_NOT_EXISTS);
         vector::remove(&mut passport.elements, index);
+    }
+
+    /// 获取用户名称
+    public fun get_name(passport: &Passport): String {
+        passport.name
+    }
+
+    /// 获取用户拥有的机器人总数
+    public fun get_total_robots(passport: &Passport): u64 {
+        vector::length(&passport.robots)
+    }
+
+    /// 获取用户拥有的元素总数
+    public fun get_total_elements(passport: &Passport): u64 {
+        vector::length(&passport.elements)
+    }
+
+    /// 获取用户拥有的所有机器人ID列表
+    public fun get_robots(passport: &Passport): &vector<ID> {
+        &passport.robots
+    }
+
+    /// 获取用户拥有的所有元素ID列表
+    public fun get_elements(passport: &Passport): &vector<ID> {
+        &passport.elements
+    }
+
+    /// 检查是否可以领取每日代币
+    #[test_only]
+    public fun can_claim_daily_token(passport: &Passport, clock: &Clock): bool {
+        let current_time = clock::timestamp_ms(clock);
+        let last_claim_time = passport.last_mint_token_time;
+        
+        // 转换为天数（毫秒转天）
+        let current_day = current_time / (1000 * 60 * 60 * 24);
+        let last_claim_day = last_claim_time / (1000 * 60 * 60 * 24);
+        
+        current_day > last_claim_day
+    }
+
+    /// 转移 Passport 给其他用户
+    public(package) fun transfer_passport(passport: Passport, recipient: address){
+        transfer::transfer(passport, recipient);
     }
 }

--- a/contract/tests/contract_tests.move
+++ b/contract/tests/contract_tests.move
@@ -1,18 +1,226 @@
-/*
 #[test_only]
-module contract::contract_tests;
-// uncomment this line to import the module
-// use contract::contract;
+module robobo::game_tests {
+    use sui::test_scenario::{Self as ts, Scenario};
+    use sui::clock;
+    use sui::test_utils::assert_eq;
+    use std::string;
+    
+    use robobo::game::{Self, GameState};
+    use robobo::user::{Self, Passport};
+    use robobo::robot::{Self, Robot, Robot_Pool};
+    use robobo::trash::{Self, TRASH, TrashTokenCap};
 
-const ENotImplemented: u64 = 0;
+    // Test constants
+    const ADMIN: address = @0xAD;
+    const USER1: address = @0x1;
+    const USER2: address = @0x2;
 
-#[test]
-fun test_contract() {
-    // pass
+    fun init_game(scenario: &mut Scenario) {
+        // 初始化游戏状态
+        ts::next_tx(scenario, ADMIN);
+        {
+            game::init_for_testing(ts::ctx(scenario));
+        };
+
+        // 初始化代币系统
+        ts::next_tx(scenario, ADMIN);
+        {
+            trash::init_for_testing(ts::ctx(scenario));
+        };
+    }
+
+    #[test]
+    fun test_game_initialization() {
+        let mut scenario = ts::begin(ADMIN);
+        
+        // 初始化游戏
+        init_game(&mut scenario);
+        
+        // 验证游戏状态已创建
+        ts::next_tx(&mut scenario, ADMIN);
+        {
+            assert!(ts::has_most_recent_shared<GameState>(), 0);
+            assert!(ts::has_most_recent_shared<Robot_Pool>(), 1);
+        };
+
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_create_passport() {
+        let mut scenario = ts::begin(ADMIN);
+        
+        // 初始化游戏
+        init_game(&mut scenario);
+        
+        // 创建用户护照
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let mut game_state = ts::take_shared<GameState>(&scenario);
+            let clock = clock::create_for_testing(ts::ctx(&mut scenario));
+            
+            game::create_passport(
+                &mut game_state,
+                string::utf8(b"User One"),
+                &clock,
+                ts::ctx(&mut scenario)
+            );
+
+            clock::destroy_for_testing(clock);
+            ts::return_shared(game_state);
+        };
+
+        // 验证护照创建成功
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let game_state = ts::take_shared<GameState>(&scenario);
+            assert!(game::has_passport(&game_state, USER1), 0);
+            ts::return_shared(game_state);
+
+            // 验证用户确实拥有护照对象
+            assert!(ts::has_most_recent_for_address<Passport>(USER1), 1);
+        };
+
+        ts::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = robobo::game::E_ALREADY_HAS_PASSPORT)]
+    fun test_create_duplicate_passport() {
+        let mut scenario = ts::begin(ADMIN);
+        
+        init_game(&mut scenario);
+        
+        // 第一次创建护照
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let mut game_state = ts::take_shared<GameState>(&scenario);
+            let clock = clock::create_for_testing(ts::ctx(&mut scenario));
+            
+            game::create_passport(
+                &mut game_state,
+                string::utf8(b"User One"),
+                &clock,
+                ts::ctx(&mut scenario)
+            );
+
+            clock::destroy_for_testing(clock);
+            ts::return_shared(game_state);
+        };
+
+        // 尝试重复创建护照（应该失败）
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let mut game_state = ts::take_shared<GameState>(&scenario);
+            let clock = clock::create_for_testing(ts::ctx(&mut scenario));
+            
+            game::create_passport(
+                &mut game_state,
+                string::utf8(b"User One Again"),
+                &clock,
+                ts::ctx(&mut scenario)
+            );
+
+            clock::destroy_for_testing(clock);
+            ts::return_shared(game_state);
+        };
+
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_create_initial_robot() {
+        let mut scenario = ts::begin(ADMIN);
+        
+        init_game(&mut scenario);
+        
+        // 创建护照
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let mut game_state = ts::take_shared<GameState>(&scenario);
+            let clock = clock::create_for_testing(ts::ctx(&mut scenario));
+            
+            game::create_passport(
+                &mut game_state,
+                string::utf8(b"User One"),
+                &clock,
+                ts::ctx(&mut scenario)
+            );
+
+            clock::destroy_for_testing(clock);
+            ts::return_shared(game_state);
+        };
+
+        // 创建初始机器人
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let game_state = ts::take_shared<GameState>(&scenario);
+            let mut robot_pool = ts::take_shared<Robot_Pool>(&scenario);
+            let mut passport = ts::take_from_sender<Passport>(&scenario);
+
+            game::create_initial_robot(
+                &game_state,
+                &mut robot_pool,
+                &mut passport,
+                string::utf8(b"First Robot"),
+                ts::ctx(&mut scenario)
+            );
+
+            ts::return_to_sender(&scenario, passport);
+            ts::return_shared(game_state);
+            ts::return_shared(robot_pool);
+        };
+
+        // 验证机器人创建成功
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let passport = ts::take_from_sender<Passport>(&scenario);
+            assert!(user::get_total_robots(&passport) == 1, 0);
+            ts::return_to_sender(&scenario, passport);
+
+            // 验证用户确实拥有机器人对象
+            assert!(ts::has_most_recent_for_address<Robot>(USER1), 1);
+        };
+
+        ts::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = robobo::game::E_NO_PASSPORT)]
+    fun test_create_robot_without_passport() {
+        let mut scenario = ts::begin(ADMIN);
+        
+        init_game(&mut scenario);
+        
+        // 尝试在没有护照的情况下创建机器人（应该失败）
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let game_state = ts::take_shared<GameState>(&scenario);
+            let mut robot_pool = ts::take_shared<Robot_Pool>(&scenario);
+            let clock = clock::create_for_testing(ts::ctx(&mut scenario));
+            
+            // 先创建一个临时护照
+            let mut passport = user::mint(
+                string::utf8(b"Temp User"),
+                &clock,
+                ts::ctx(&mut scenario)
+            );
+            
+            // 这里会失败，因为用户没有在 game_state 中注册护照
+            game::create_initial_robot(
+                &game_state,
+                &mut robot_pool,
+                &mut passport,
+                string::utf8(b"First Robot"),
+                ts::ctx(&mut scenario)
+            );
+
+            clock::destroy_for_testing(clock);
+            ts::return_shared(game_state);
+            ts::return_shared(robot_pool);
+            user::transfer_passport(passport, USER1);
+        };
+
+        ts::end(scenario);
+    }
 }
-
-#[test, expected_failure(abort_code = ::contract::contract_tests::ENotImplemented)]
-fun test_contract_fail() {
-    abort ENotImplemented
-}
-*/

--- a/contract/tests/contract_tests.move
+++ b/contract/tests/contract_tests.move
@@ -1,19 +1,24 @@
 #[test_only]
 module robobo::game_tests {
     use sui::test_scenario::{Self as ts, Scenario};
-    use sui::clock;
+    use sui::tx_context;
     use sui::test_utils::assert_eq;
     use std::string;
+    use sui::table;
     
     use robobo::game::{Self, GameState};
     use robobo::user::{Self, Passport};
     use robobo::robot::{Self, Robot, Robot_Pool};
     use robobo::trash::{Self, TRASH, TrashTokenCap};
+    use sui::token::{Self, Token, TokenPolicy};
 
     // Test constants
     const ADMIN: address = @0xAD;
     const USER1: address = @0x1;
     const USER2: address = @0x2;
+
+    // Game constants
+    const TRASH_AMOUNT_DAILY_CLAIM: u64 = 100;
 
     fun init_game(scenario: &mut Scenario) {
         // 初始化游戏状态
@@ -41,6 +46,8 @@ module robobo::game_tests {
         {
             assert!(ts::has_most_recent_shared<GameState>(), 0);
             assert!(ts::has_most_recent_shared<Robot_Pool>(), 1);
+            assert!(ts::has_most_recent_shared<TokenPolicy<TRASH>>(), 1);
+            assert!(ts::has_most_recent_shared<TrashTokenCap>(), 1);
         };
 
         ts::end(scenario);
@@ -57,17 +64,17 @@ module robobo::game_tests {
         ts::next_tx(&mut scenario, USER1);
         {
             let mut game_state = ts::take_shared<GameState>(&scenario);
-            let clock = clock::create_for_testing(ts::ctx(&mut scenario));
+            let mut token_cap = ts::take_shared<TrashTokenCap>(&scenario);
             
             game::create_passport(
-                &mut game_state,
                 string::utf8(b"User One"),
-                &clock,
+                &mut game_state,
+                &mut token_cap,
                 ts::ctx(&mut scenario)
             );
 
-            clock::destroy_for_testing(clock);
             ts::return_shared(game_state);
+            ts::return_shared(token_cap);
         };
 
         // 验证护照创建成功
@@ -79,6 +86,25 @@ module robobo::game_tests {
 
             // 验证用户确实拥有护照对象
             assert!(ts::has_most_recent_for_address<Passport>(USER1), 1);
+        };
+
+        // 验证用户创建护照后，游戏状态中的 passport 数量增加
+        ts::next_tx(&mut scenario, ADMIN);
+        {
+            let game_state = ts::take_shared<GameState>(&scenario);
+            assert!(game::has_passport(&game_state, USER1), 0);
+            ts::return_shared(game_state);
+        };
+
+        // 验证用户创建护照后,账户的token数量
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let passport = ts::take_from_sender<Passport>(&scenario);
+            // 验证用户的token数量
+            let token = ts::take_from_sender<Token<TRASH>>(&scenario);
+            assert!(token::value(&token) == 100, 0);
+            ts::return_to_sender(&scenario, token);
+            ts::return_to_sender(&scenario, passport);
         };
 
         ts::end(scenario);
@@ -95,34 +121,34 @@ module robobo::game_tests {
         ts::next_tx(&mut scenario, USER1);
         {
             let mut game_state = ts::take_shared<GameState>(&scenario);
-            let clock = clock::create_for_testing(ts::ctx(&mut scenario));
+            let mut token_cap = ts::take_shared<TrashTokenCap>(&scenario);
             
             game::create_passport(
-                &mut game_state,
                 string::utf8(b"User One"),
-                &clock,
+                &mut game_state,
+                &mut token_cap,
                 ts::ctx(&mut scenario)
             );
 
-            clock::destroy_for_testing(clock);
             ts::return_shared(game_state);
+            ts::return_shared(token_cap);
         };
 
         // 尝试重复创建护照（应该失败）
         ts::next_tx(&mut scenario, USER1);
         {
             let mut game_state = ts::take_shared<GameState>(&scenario);
-            let clock = clock::create_for_testing(ts::ctx(&mut scenario));
+            let mut token_cap = ts::take_shared<TrashTokenCap>(&scenario);
             
             game::create_passport(
-                &mut game_state,
                 string::utf8(b"User One Again"),
-                &clock,
+                &mut game_state,
+                &mut token_cap,
                 ts::ctx(&mut scenario)
             );
 
-            clock::destroy_for_testing(clock);
             ts::return_shared(game_state);
+            ts::return_shared(token_cap);
         };
 
         ts::end(scenario);
@@ -138,17 +164,28 @@ module robobo::game_tests {
         ts::next_tx(&mut scenario, USER1);
         {
             let mut game_state = ts::take_shared<GameState>(&scenario);
-            let clock = clock::create_for_testing(ts::ctx(&mut scenario));
+            let mut token_cap = ts::take_shared<TrashTokenCap>(&scenario);
             
             game::create_passport(
-                &mut game_state,
                 string::utf8(b"User One"),
-                &clock,
+                &mut game_state,
+                &mut token_cap,
                 ts::ctx(&mut scenario)
             );
 
-            clock::destroy_for_testing(clock);
             ts::return_shared(game_state);
+            ts::return_shared(token_cap);
+        };
+
+        // 验证用户创建护照后,账户的token数量
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let passport = ts::take_from_sender<Passport>(&scenario);
+            // 验证用户的token数量
+            let token = ts::take_from_sender<Token<TRASH>>(&scenario);
+            assert!(token::value(&token) == 100, 0);
+            ts::return_to_sender(&scenario, token);
+            ts::return_to_sender(&scenario, passport);
         };
 
         // 创建初始机器人
@@ -157,18 +194,31 @@ module robobo::game_tests {
             let game_state = ts::take_shared<GameState>(&scenario);
             let mut robot_pool = ts::take_shared<Robot_Pool>(&scenario);
             let mut passport = ts::take_from_sender<Passport>(&scenario);
+            let mut token_policy = ts::take_shared<TokenPolicy<TRASH>>(&scenario);
+            let token_cap = ts::take_shared<TrashTokenCap>(&scenario);
 
-            game::create_initial_robot(
+            // 先获取一些 TRASH token
+            let mut token = ts::take_from_sender<Token<TRASH>>(&scenario);
+            // 分割出正确数量的token作为支付
+            let payment = token::split(&mut token, 10, ts::ctx(&mut scenario));
+            // 把剩余的token还给用户
+            ts::return_to_sender(&scenario, token);
+
+            game::mint_robot(
                 &game_state,
                 &mut robot_pool,
                 &mut passport,
                 string::utf8(b"First Robot"),
+                payment,
+                &mut token_policy,
                 ts::ctx(&mut scenario)
             );
 
             ts::return_to_sender(&scenario, passport);
             ts::return_shared(game_state);
             ts::return_shared(robot_pool);
+            ts::return_shared(token_policy);
+            ts::return_shared(token_cap);
         };
 
         // 验证机器人创建成功
@@ -192,33 +242,192 @@ module robobo::game_tests {
         
         init_game(&mut scenario);
         
+        // 先铸造token
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let mut token_cap = ts::take_shared<TrashTokenCap>(&scenario);
+            trash::mint(&mut token_cap, 10, ts::ctx(&mut scenario));
+            ts::return_shared(token_cap);
+        };
+        
         // 尝试在没有护照的情况下创建机器人（应该失败）
         ts::next_tx(&mut scenario, USER1);
         {
             let game_state = ts::take_shared<GameState>(&scenario);
             let mut robot_pool = ts::take_shared<Robot_Pool>(&scenario);
-            let clock = clock::create_for_testing(ts::ctx(&mut scenario));
+            let mut token_policy = ts::take_shared<TokenPolicy<TRASH>>(&scenario);
             
-            // 先创建一个临时护照
+            // 创建一个临时护照
             let mut passport = user::mint(
                 string::utf8(b"Temp User"),
-                &clock,
                 ts::ctx(&mut scenario)
             );
             
+            // 获取之前铸造的token
+            let payment = ts::take_from_sender<Token<TRASH>>(&scenario);
+
             // 这里会失败，因为用户没有在 game_state 中注册护照
-            game::create_initial_robot(
+            game::mint_robot(
                 &game_state,
                 &mut robot_pool,
                 &mut passport,
                 string::utf8(b"First Robot"),
+                payment,
+                &mut token_policy,
                 ts::ctx(&mut scenario)
             );
 
-            clock::destroy_for_testing(clock);
             ts::return_shared(game_state);
             ts::return_shared(robot_pool);
+            ts::return_shared(token_policy);
             user::transfer_passport(passport, USER1);
+        };
+
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_claim_daily_token() {
+        let mut scenario = ts::begin(ADMIN);
+        
+        init_game(&mut scenario);
+        
+        // 创建护照
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let mut game_state = ts::take_shared<GameState>(&scenario);
+            let mut token_cap = ts::take_shared<TrashTokenCap>(&scenario);
+            
+            game::create_passport(
+                string::utf8(b"User One"),
+                &mut game_state,
+                &mut token_cap,
+                ts::ctx(&mut scenario)
+            );
+
+            ts::return_shared(game_state);
+            ts::return_shared(token_cap);
+        };
+
+        // 验证用户创建护照后的初始token数量
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let passport = ts::take_from_sender<Passport>(&scenario);
+            let token = ts::take_from_sender<Token<TRASH>>(&scenario);
+            assert!(token::value(&token) == TRASH_AMOUNT_DAILY_CLAIM, 0);
+            ts::return_to_sender(&scenario, token);
+            ts::return_to_sender(&scenario, passport);
+        };
+
+        // 等待一天
+        ts::next_tx(&mut scenario, USER1);
+        {
+            tx_context::increment_epoch_timestamp(ts::ctx(&mut scenario), 1000 * 60 * 60 * 24);
+        };
+
+        // 领取每日token
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let mut passport = ts::take_from_sender<Passport>(&scenario);
+            let game_state = ts::take_shared<GameState>(&scenario);
+            let mut token_cap = ts::take_shared<TrashTokenCap>(&scenario);
+            
+            game::claim_daily_token(
+                &game_state,
+                &mut passport,
+                &mut token_cap,
+                ts::ctx(&mut scenario)
+            );
+
+            ts::return_to_sender(&scenario, passport);
+            ts::return_shared(game_state);
+            ts::return_shared(token_cap);
+        };
+
+        // 验证领取后的token数量
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let passport = ts::take_from_sender<Passport>(&scenario);
+            let mut token1 = ts::take_from_sender<Token<TRASH>>(&scenario);
+            let token2 = ts::take_from_sender<Token<TRASH>>(&scenario);
+            
+            // 合并两个token
+            token::join(&mut token1, token2);
+            assert!(token::value(&token1) == TRASH_AMOUNT_DAILY_CLAIM * 2, 0);
+            
+            ts::return_to_sender(&scenario, token1);
+            ts::return_to_sender(&scenario, passport);
+        };
+
+        ts::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = robobo::game::E_ALREADY_CLAIMED_TODAY)]
+    fun test_claim_daily_token_twice() {
+        let mut scenario = ts::begin(ADMIN);
+        
+        init_game(&mut scenario);
+        
+        // 创建护照
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let mut game_state = ts::take_shared<GameState>(&scenario);
+            let mut token_cap = ts::take_shared<TrashTokenCap>(&scenario);
+            
+            game::create_passport(
+                string::utf8(b"User One"),
+                &mut game_state,
+                &mut token_cap,
+                ts::ctx(&mut scenario)
+            );
+
+            ts::return_shared(game_state);
+            ts::return_shared(token_cap);
+        };
+
+        // 等待一天
+        ts::next_tx(&mut scenario, USER1);
+        {
+            tx_context::increment_epoch_timestamp(ts::ctx(&mut scenario), 1000 * 60 * 60 * 24);
+        };
+
+        // 第一次领取每日token
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let mut passport = ts::take_from_sender<Passport>(&scenario);
+            let game_state = ts::take_shared<GameState>(&scenario);
+            let mut token_cap = ts::take_shared<TrashTokenCap>(&scenario);
+            
+            game::claim_daily_token(
+                &game_state,
+                &mut passport,
+                &mut token_cap,
+                ts::ctx(&mut scenario)
+            );
+
+            ts::return_to_sender(&scenario, passport);
+            ts::return_shared(game_state);
+            ts::return_shared(token_cap);
+        };
+
+        // 尝试第二次领取（应该失败）
+        ts::next_tx(&mut scenario, USER1);
+        {
+            let mut passport = ts::take_from_sender<Passport>(&scenario);
+            let game_state = ts::take_shared<GameState>(&scenario);
+            let mut token_cap = ts::take_shared<TrashTokenCap>(&scenario);
+            
+            game::claim_daily_token(
+                &game_state,
+                &mut passport,
+                &mut token_cap,
+                ts::ctx(&mut scenario)
+            );
+
+            ts::return_to_sender(&scenario, passport);
+            ts::return_shared(game_state);
+            ts::return_shared(token_cap);
         };
 
         ts::end(scenario);

--- a/contract/tests/user_tests.move
+++ b/contract/tests/user_tests.move
@@ -1,0 +1,304 @@
+#[test_only]
+module robobo::user_tests {
+    use sui::test_scenario::{Self as ts, Scenario};
+    use sui::clock::{Self, Clock};
+    use sui::test_utils;
+    use sui::object;
+    use sui::transfer;
+    use std::string;
+    use robobo::user::{Self, Passport};
+
+    const USER1: address = @0xA1;
+    const USER2: address = @0xA2;
+
+    fun test_scenario(): Scenario { ts::begin(USER1) }
+
+    #[test]
+    fun test_create_user() {
+        let mut scenario = test_scenario();
+        let test = &mut scenario;
+        
+        // 创建时钟
+        ts::next_tx(test, USER1);
+        let ctx = ts::ctx(test);
+        let mut clock = clock::create_for_testing(ctx);
+        clock::set_for_testing(&mut clock, 0);
+
+        // 创建用户
+        ts::next_tx(test, USER1);
+        {
+            let ctx = ts::ctx(test);
+            let passport = user::mint(string::utf8(b"Test User"), &clock, ctx);
+            user::transfer_passport(passport, USER1);
+        };
+
+        // 验证用户创建
+        ts::next_tx(test, USER1);
+        {
+            let passport = ts::take_from_sender<Passport>(test);
+            assert!(user::get_name(&passport) == string::utf8(b"Test User"), 0);
+            let robots = user::get_robots(&passport);
+            let elements = user::get_elements(&passport);
+            assert!(vector::is_empty(robots), 1);
+            assert!(vector::is_empty(elements), 2);
+            ts::return_to_sender(test, passport);
+        };
+
+        clock::destroy_for_testing(clock);
+        ts::end(scenario);
+    }
+    
+    #[test]
+    fun test_robot_management() {
+        let mut scenario = test_scenario();
+        let test = &mut scenario;
+        
+        // 创建时钟和用户
+        ts::next_tx(test, USER1);
+        let ctx = ts::ctx(test);
+        let mut clock = clock::create_for_testing(ctx);
+        clock::set_for_testing(&mut clock, 0);
+
+         // 创建用户
+        ts::next_tx(test, USER1);
+        {
+            let ctx = ts::ctx(test);
+            let passport = user::mint(string::utf8(b"Test User"), &clock, ctx);
+            user::transfer_passport(passport, USER1);
+        };
+
+        // 测试添加机器人
+        ts::next_tx(test, USER1);
+        {
+            let mut passport = ts::take_from_sender<Passport>(test);
+            let robot_id = object::id_from_address(@0x1);
+            
+            user::add_robot(&mut passport, robot_id);
+            assert!(vector::length(user::get_robots(&passport)) == 1, 5);
+            assert!(vector::contains(user::get_robots(&passport), &robot_id), 6);
+            
+            ts::return_to_sender(test, passport);
+        };
+
+        // 测试删除机器人
+        ts::next_tx(test, USER1);
+        {
+            let mut passport = ts::take_from_sender<Passport>(test);
+            let robot_id = object::id_from_address(@0x1);
+            
+            user::remove_robot(&mut passport, robot_id);
+            assert!(vector::length(user::get_robots(&passport)) == 0, 7);
+            assert!(!vector::contains(user::get_robots(&passport), &robot_id), 8);
+            
+            ts::return_to_sender(test, passport);
+        };
+
+        clock::destroy_for_testing(clock);
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_edit_name() {
+        let mut scenario = test_scenario();
+        let test = &mut scenario;
+        
+        // 创建时钟和用户
+        ts::next_tx(test, USER1);
+        let ctx = ts::ctx(test);
+        let mut clock = clock::create_for_testing(ctx);
+        clock::set_for_testing(&mut clock, 0);
+
+        // 创建用户
+        ts::next_tx(test, USER1);
+        {
+            let ctx = ts::ctx(test);
+            let passport = user::mint(string::utf8(b"Test User"), &clock, ctx);
+            user::transfer_passport(passport, USER1);
+        };
+
+        // 测试修改名称
+        ts::next_tx(test, USER1);
+        {
+            let mut passport = ts::take_from_sender<Passport>(test);
+            user::edit_name(&mut passport, string::utf8(b"New Name"));
+            assert!(user::get_name(&passport) == string::utf8(b"New Name"), 7);
+            ts::return_to_sender(test, passport);
+        };
+
+        clock::destroy_for_testing(clock);
+        ts::end(scenario);
+    }
+
+    #[test]
+    fun test_element_management() {
+        let mut scenario = test_scenario();
+        let test = &mut scenario;
+        
+        // 创建时钟和用户
+        ts::next_tx(test, USER1);
+        let ctx = ts::ctx(test);
+        let mut clock = clock::create_for_testing(ctx);
+        clock::set_for_testing(&mut clock, 0);
+
+        // 创建用户
+        ts::next_tx(test, USER1);
+        {
+            let ctx = ts::ctx(test);
+            let passport = user::mint(string::utf8(b"Test User"), &clock, ctx);
+            user::transfer_passport(passport, USER1);
+        };
+
+        // 测试添加元素
+        ts::next_tx(test, USER1);
+        {
+            let mut passport = ts::take_from_sender<Passport>(test);
+            let element_id = object::id_from_address(@0x2);
+            
+            user::add_element(&mut passport, element_id);
+            assert!(vector::length(user::get_elements(&passport)) == 1, 8);
+            assert!(vector::contains(user::get_elements(&passport), &element_id), 9);
+            
+            ts::return_to_sender(test, passport);
+        };
+
+        // 测试移除元素
+        ts::next_tx(test, USER1);
+        {
+            let mut passport = ts::take_from_sender<Passport>(test);
+            let element_id = object::id_from_address(@0x2);
+            
+            user::remove_element(&mut passport, element_id);
+            assert!(vector::length(user::get_elements(&passport)) == 0, 10);
+            assert!(!vector::contains(user::get_elements(&passport), &element_id), 11);
+            
+            ts::return_to_sender(test, passport);
+        };
+
+        clock::destroy_for_testing(clock);
+        ts::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = user::E_ROBOT_EXISTS)]
+    fun test_add_duplicate_robot() {
+        let mut scenario = test_scenario();
+        let test = &mut scenario;
+        
+        // 创建时钟和用户
+        ts::next_tx(test, USER1);
+        let ctx = ts::ctx(test);
+        let mut clock = clock::create_for_testing(ctx);
+        clock::set_for_testing(&mut clock, 0);
+        
+        // 创建用户
+        ts::next_tx(test, USER1);
+        {
+            let ctx = ts::ctx(test);
+            let passport = user::mint(string::utf8(b"Test User"), &clock, ctx);
+            user::transfer_passport(passport, USER1);
+        };
+
+        // 测试添加重复机器人
+        ts::next_tx(test, USER1);
+        {
+            let mut passport = ts::take_from_sender<Passport>(test);
+            let robot_id = object::id_from_address(@0x1);
+            
+            user::add_robot(&mut passport, robot_id);
+            // 这里应该会失败
+            user::add_robot(&mut passport, robot_id);
+            
+            ts::return_to_sender(test, passport);
+        };
+
+        clock::destroy_for_testing(clock);
+        ts::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = user::E_ROBOT_NOT_EXISTS)]
+    fun test_remove_nonexistent_robot() {
+        let mut scenario = test_scenario();
+        let test = &mut scenario;
+        
+        // 创建时钟和用户
+        ts::next_tx(test, USER1);
+        let ctx = ts::ctx(test);
+        let mut clock = clock::create_for_testing(ctx);
+        clock::set_for_testing(&mut clock, 0);
+
+        // 创建用户
+        ts::next_tx(test, USER1);
+        {
+            let ctx = ts::ctx(test);
+            let passport = user::mint(string::utf8(b"Test User"), &clock, ctx);
+            user::transfer_passport(passport, USER1);
+        };
+
+        // 测试移除不存在的机器人
+        ts::next_tx(test, USER1);
+        {
+            let mut passport = ts::take_from_sender<Passport>(test);
+            let robot_id = object::id_from_address(@0x1);
+            
+            // 这里应该会失败
+            user::remove_robot(&mut passport, robot_id);
+            
+            ts::return_to_sender(test, passport);
+        };
+
+        clock::destroy_for_testing(clock);
+        ts::end(scenario);
+    }
+
+
+
+    #[test]
+    fun test_daily_token_claim() {
+        let mut scenario = test_scenario();
+        let test = &mut scenario;
+        
+        // 创建时钟
+        ts::next_tx(test, USER1);
+        let ctx = ts::ctx(test);
+        let mut clock = clock::create_for_testing(ctx);
+        clock::set_for_testing(&mut clock, 0);  // 从0时间开始
+
+        // 创建用户
+        ts::next_tx(test, USER1);
+        {
+            let ctx = ts::ctx(test);
+            let passport = user::mint(string::utf8(b"Test User"), &clock, ctx);
+            user::transfer_passport(passport, USER1);
+        };
+
+        // 尝试立即领取代币（应该失败，因为在同一天）
+        ts::next_tx(test, USER1);
+        {
+            let passport = ts::take_from_sender<Passport>(test);
+            assert!(!user::can_claim_daily_token(&passport, &clock), 3);
+            ts::return_to_sender(test, passport);
+        };
+
+        // 快进23小时（应该还是在同一天）
+        clock::increment_for_testing(&mut clock, 1000 * 60 * 60 * 23);
+        ts::next_tx(test, USER1);
+        {
+            let passport = ts::take_from_sender<Passport>(test);
+            assert!(!user::can_claim_daily_token(&passport, &clock), 4);
+            ts::return_to_sender(test, passport);
+        };
+
+        // 再快进2小时（应该进入下一天）
+        clock::increment_for_testing(&mut clock, 1000 * 60 * 60 * 2);
+        ts::next_tx(test, USER1);
+        {
+            let passport = ts::take_from_sender<Passport>(test);
+            assert!(user::can_claim_daily_token(&passport, &clock), 5);
+            ts::return_to_sender(test, passport);
+        };
+
+        clock::destroy_for_testing(clock);
+        ts::end(scenario);
+    }
+} 


### PR DESCRIPTION
### 1. 用户系统 (User) 已完成的流程
1. **基础用户管理**
   - ✅ 创建用户护照 (`mint`)
   - ✅ 修改用户名称 (`edit_name`)
   - ✅ 转移护照功能 (`transfer_passport`)

2. **资产管理**
   - ✅ 添加/移除机器人 (`add_robot`/`remove_robot`)
   - ✅ 添加/移除元素 (`add_element`/`remove_element`)
   - ✅ 查询用户拥有的机器人和元素

3. **代币相关**
   - ✅ 每日代币领取检查 (`can_claim_daily_token`)
   - ✅ 上次领取时间记录 (`last_mint_token_time`)

### 2. 游戏系统 (Game) 已完成的流程
1. **初始化功能**
   - ✅ 游戏状态初始化
   - ✅ 机器人池初始化
   - ✅ 代币系统初始化

2. **护照管理**
   - ✅ 创建用户护照
   - ✅ 护照验证
   - ✅ 护照查询

3. **代币功能**
   - ✅ 每日代币领取
   - ✅ 代币消费（创建机器人）

4. **机器人管理**
   - ✅ 创建初始机器人
   - ✅ 机器人属性计算

### 3. 测试用例 (Tests) 已完成的流程
1. **用户测试 (user_tests.move)**
   - ✅ 创建用户测试
   - ✅ 机器人管理测试
   - ✅ 修改用户名称测试
   - ✅ 元素管理测试
   - ✅ 每日代币领取测试
   - ✅ 错误处理测试（重复添加、移除不存在项）

2. **合约测试 (contract_tests.move)**
   - ✅ 游戏初始化测试
   - ✅ 护照创建测试
   - ✅ 初始机器人创建测试
   - ✅ 代币领取测试
   - ✅ 错误处理测试
